### PR TITLE
allow redirects between hosts

### DIFF
--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -392,21 +392,6 @@ func TestSignInPageIncludesTargetRedirect(t *testing.T) {
 	}
 }
 
-func TestSignInPageDirectAccessRedirectsToRoot(t *testing.T) {
-	sip_test := NewSignInPageTest()
-	code, body := sip_test.GetEndpoint("/oauth2/sign_in")
-	assert.Equal(t, 200, code)
-
-	match := sip_test.sign_in_regexp.FindStringSubmatch(body)
-	if match == nil {
-		t.Fatal("Did not find pattern in body: " +
-			signInRedirectPattern + "\nBody:\n" + body)
-	}
-	if match[1] != "/" {
-		t.Fatal(`expected redirect to "/", but was "` + match[1] + `"`)
-	}
-}
-
 type ProcessCookieTest struct {
 	opts          *Options
 	proxy         *OAuthProxy

--- a/providers/provider_default.go
+++ b/providers/provider_default.go
@@ -8,7 +8,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"strings"
 
 	"github.com/bitly/oauth2_proxy/cookie"
 )
@@ -88,9 +87,8 @@ func (p *ProviderData) GetLoginURL(redirectURI, finalRedirect string) string {
 	params.Add("scope", p.Scope)
 	params.Set("client_id", p.ClientID)
 	params.Set("response_type", "code")
-	if strings.HasPrefix(finalRedirect, "/") {
-		params.Add("state", finalRedirect)
-	}
+	params.Add("state", finalRedirect)
+
 	a.RawQuery = params.Encode()
 	return a.String()
 }


### PR DESCRIPTION
Allows redirects between hostnames within the same authorization realm. Intended use is to run a central auth host that generates auth cookies for an entire domain. E.g. if you visit `secure.domain.com/resource` without a valid auth cookie, you'll be redirected to `auth.domain.com` to be authorized and granted a cookie valid for `*.domain.com`, then you'll be redirected back to `secure1.domain.com/resource`.
